### PR TITLE
feat: build rhythm game with react and tailwind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+dist
+.DS_Store
+.idea
+.vscode
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# -
-Codexに接続するリポジトリ
+# Rhythm Flow
+
+Vite + React + TypeScriptで構築した4レーンの簡易リズムゲームです。Web Audio APIを利用したメトロノームトラック、BPMと小節数からの譜面自動生成、判定システムやオフセット・スクロール速度調整などを実装しています。
+
+## 主な機能
+
+- D/F/J/Kキーでプレイする4レーンのノーツレーン
+- BPM・小節数・拍子・分解能・乱数シードからの譜面自動生成
+- PERFECT / GREAT / GOOD / MISS の判定とコンボ・精度計算
+- オーディオオフセットとスクロール速度のリアルタイム調整
+- Tailwind CSSによるスタイリング
+- Vitest + Testing Libraryによる簡易ユニットテスト
+
+## スクリプト
+
+```bash
+npm install
+npm run dev
+npm run build
+npm run test
+npm run lint
+```
+
+## 開発メモ
+
+- Web Audio APIはユーザー操作後に有効化されるため、`スタート`ボタンを押してプレイを開始してください。
+- 判定ウィンドウやスコア係数は `src/lib/judgement.ts` で定義しています。

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,38 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import prettierConfig from 'eslint-config-prettier';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.app.json'],
+        ecmaFeatures: { jsx: true }
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.node
+      }
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }]
+    }
+  },
+  {
+    rules: {
+      ...prettierConfig.rules
+    }
+  }
+);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rhythm Flow</title>
+  </head>
+  <body class="bg-slate-900 text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "rhythm-game",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "test": "vitest",
+    "lint": "eslint . --ext ts,tsx --max-warnings=0",
+    "format": "prettier --write .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.2",
+    "@typescript-eslint/eslint-plugin": "^8.8.1",
+    "@typescript-eslint/parser": "^8.8.1",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^9.14.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-react-refresh": "^0.4.11",
+    "globals": "^15.11.0",
+    "jsdom": "^25.0.1",
+    "postcss": "^8.4.47",
+    "prettier": "^3.3.3",
+    "tailwindcss": "^3.4.14",
+    "typescript-eslint": "^8.8.1",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10",
+    "vitest": "^2.1.6"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import App from './App';
+
+describe('App', () => {
+  it('renders header and controls', () => {
+    render(<App />);
+    expect(screen.getByText('Rhythm Flow')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'スタート' })).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: /スクロール速度/i })).toBeInTheDocument();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,433 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import GameBoard from './components/GameBoard';
+import { AudioEngine } from './lib/audio';
+import { generateChart } from './lib/chart';
+import { determineJudgement, judgementWeights, judgementWindows, type Judgement } from './lib/judgement';
+import type { ChartConfig, ChartData, NoteState } from './types';
+
+const laneKeyMap: Record<string, number> = {
+  KeyD: 0,
+  KeyF: 1,
+  KeyJ: 2,
+  KeyK: 3
+};
+
+const defaultConfig: ChartConfig = {
+  bpm: 140,
+  measures: 8,
+  beatsPerMeasure: 4,
+  resolution: 4,
+  seed: 2024
+};
+
+interface GameStats {
+  combo: number;
+  maxCombo: number;
+  counts: Record<Judgement, number>;
+  score: number;
+  totalJudged: number;
+  accuracy: number;
+  lastJudgement: Judgement | null;
+}
+
+const createInitialStats = (): GameStats => ({
+  combo: 0,
+  maxCombo: 0,
+  counts: {
+    PERFECT: 0,
+    GREAT: 0,
+    GOOD: 0,
+    MISS: 0
+  },
+  score: 0,
+  totalJudged: 0,
+  accuracy: 100,
+  lastJudgement: null
+});
+
+const toNoteState = (chart: ChartData): NoteState[] =>
+  chart.notes.map((note) => ({
+    ...note,
+    status: 'pending' as const
+  }));
+
+const formatAccuracy = (value: number) => `${value.toFixed(2)}%`;
+
+function App() {
+  const [chartConfig, setChartConfig] = useState<ChartConfig>(defaultConfig);
+  const [chart, setChart] = useState<ChartData>(() => generateChart(defaultConfig));
+  const [noteStates, setNoteStates] = useState<NoteState[]>(() => toNoteState(chart));
+  const [stats, setStats] = useState<GameStats>(() => createInitialStats());
+  const [scrollSpeed, setScrollSpeed] = useState(1.1);
+  const [offset, setOffset] = useState(0);
+  const [started, setStarted] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [pressed, setPressed] = useState<Record<number, boolean>>({ 0: false, 1: false, 2: false, 3: false });
+
+  const audioEngineRef = useRef<AudioEngine | null>(null);
+  const currentTimeRef = useRef(0);
+  currentTimeRef.current = currentTime;
+
+  const totalNotes = chart.notes.length;
+
+  useEffect(() => {
+    setChart(generateChart(chartConfig));
+  }, [chartConfig]);
+
+  useEffect(() => {
+    setNoteStates(toNoteState(chart));
+    setStats(createInitialStats());
+    setCurrentTime(0);
+    setStarted(false);
+
+    const prepare = async () => {
+      if (!audioEngineRef.current) {
+        audioEngineRef.current = new AudioEngine();
+      }
+      try {
+        await audioEngineRef.current.prepare(chart);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to prepare audio', error);
+      }
+    };
+
+    prepare();
+  }, [chart]);
+
+  const offsetSeconds = useMemo(() => offset / 1000, [offset]);
+
+  const applyJudgement = useCallback(
+    (judgement: Judgement) => {
+      setStats((previous) => {
+        const nextCounts = {
+          ...previous.counts,
+          [judgement]: previous.counts[judgement] + 1
+        };
+        const nextCombo = judgement === 'MISS' ? 0 : previous.combo + 1;
+        const nextMaxCombo = Math.max(previous.maxCombo, nextCombo);
+        const nextTotal = previous.totalJudged + 1;
+        const nextScore = previous.score + judgementWeights[judgement];
+        const accuracy = nextTotal === 0 ? 100 : (nextScore / nextTotal) * 100;
+
+        return {
+          combo: nextCombo,
+          maxCombo: nextMaxCombo,
+          counts: nextCounts,
+          score: nextScore,
+          totalJudged: nextTotal,
+          accuracy,
+          lastJudgement: judgement
+        };
+      });
+    },
+    [setStats]
+  );
+
+  const markMisses = useCallback(
+    (now: number) => {
+      const expired: NoteState[] = [];
+      setNoteStates((previous) => {
+        let mutated = false;
+        const next = previous.map((note) => {
+          if (note.status !== 'pending') {
+            return note;
+          }
+          if (note.time + judgementWindows.GOOD < now + offsetSeconds) {
+            mutated = true;
+            const missed: NoteState = {
+              ...note,
+              status: 'MISS',
+              hitOffset: now + offsetSeconds - note.time
+            };
+            expired.push(missed);
+            return missed;
+          }
+          return note;
+        });
+        if (!mutated) {
+          return previous;
+        }
+        return next;
+      });
+      if (expired.length > 0) {
+        expired.forEach(() => applyJudgement('MISS'));
+      }
+    },
+    [applyJudgement, offsetSeconds]
+  );
+
+  const handleHit = useCallback(
+    (lane: number) => {
+      if (!started) {
+        return;
+      }
+      const now = currentTimeRef.current + offsetSeconds;
+      let recordedJudgement: Judgement | null = null;
+
+      setNoteStates((previous) => {
+        let targetIndex = -1;
+        let targetDelta = Number.POSITIVE_INFINITY;
+
+        previous.forEach((note, index) => {
+          if (note.lane !== lane || note.status !== 'pending') {
+            return;
+          }
+          const delta = note.time - now;
+          if (Math.abs(delta) < Math.abs(targetDelta)) {
+            targetDelta = delta;
+            targetIndex = index;
+          }
+        });
+
+        if (targetIndex === -1) {
+          recordedJudgement = 'MISS';
+          return previous;
+        }
+
+        const judgement = determineJudgement(targetDelta);
+        if (!judgement) {
+          recordedJudgement = 'MISS';
+          return previous;
+        }
+
+        const next = [...previous];
+        const target = previous[targetIndex];
+        next[targetIndex] = {
+          ...target,
+          status: judgement,
+          hitOffset: targetDelta
+        };
+        recordedJudgement = judgement;
+        return next;
+      });
+
+      if (recordedJudgement) {
+        applyJudgement(recordedJudgement);
+      }
+    },
+    [applyJudgement, offsetSeconds, started]
+  );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const lane = laneKeyMap[event.code];
+      if (lane === undefined) {
+        return;
+      }
+      event.preventDefault();
+      setPressed((previous) => {
+        if (previous[lane]) {
+          return previous;
+        }
+        return { ...previous, [lane]: true };
+      });
+      handleHit(lane);
+    };
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      const lane = laneKeyMap[event.code];
+      if (lane === undefined) {
+        return;
+      }
+      event.preventDefault();
+      setPressed((previous) => ({ ...previous, [lane]: false }));
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  }, [handleHit]);
+
+  useEffect(() => {
+    if (!started) {
+      return;
+    }
+    let raf = 0;
+    const loop = () => {
+      const now = audioEngineRef.current?.getCurrentTime() ?? currentTimeRef.current;
+      setCurrentTime(now);
+      markMisses(now);
+      raf = window.requestAnimationFrame(loop);
+    };
+    raf = window.requestAnimationFrame(loop);
+    return () => window.cancelAnimationFrame(raf);
+  }, [markMisses, started]);
+
+  const startGame = async () => {
+    if (!audioEngineRef.current) {
+      audioEngineRef.current = new AudioEngine();
+    }
+    try {
+      await audioEngineRef.current.prepare(chart);
+      await audioEngineRef.current.play();
+      setNoteStates(toNoteState(chart));
+      setStats(createInitialStats());
+      setCurrentTime(0);
+      setStarted(true);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Unable to start audio context', error);
+    }
+  };
+
+  const stopGame = () => {
+    audioEngineRef.current?.stop();
+    setStarted(false);
+    setCurrentTime(0);
+  };
+
+  const onConfigChange = (partial: Partial<ChartConfig>) => {
+    setChartConfig((previous) => ({ ...previous, ...partial }));
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center gap-6 p-6">
+      <header className="flex w-full max-w-5xl flex-col gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Rhythm Flow</h1>
+          <p className="text-sm text-slate-300">
+            D/F/J/Kでプレイ。メトロノームトラックに合わせて4レーンの譜面を自動生成します。
+          </p>
+        </div>
+        <section className="grid grid-cols-1 gap-4 rounded-xl bg-slate-800/40 p-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase text-slate-300">BPM</span>
+            <input
+              type="number"
+              className="rounded border border-slate-600 bg-slate-900 p-2"
+              value={chartConfig.bpm}
+              min={60}
+              max={220}
+              onChange={(event) => onConfigChange({ bpm: Number(event.target.value) })}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase text-slate-300">小節数</span>
+            <input
+              type="number"
+              className="rounded border border-slate-600 bg-slate-900 p-2"
+              value={chartConfig.measures}
+              min={1}
+              max={32}
+              onChange={(event) => onConfigChange({ measures: Number(event.target.value) })}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase text-slate-300">拍子</span>
+            <input
+              type="number"
+              className="rounded border border-slate-600 bg-slate-900 p-2"
+              value={chartConfig.beatsPerMeasure}
+              min={2}
+              max={7}
+              onChange={(event) => onConfigChange({ beatsPerMeasure: Number(event.target.value) })}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase text-slate-300">分解能</span>
+            <select
+              className="rounded border border-slate-600 bg-slate-900 p-2"
+              value={chartConfig.resolution}
+              onChange={(event) => onConfigChange({ resolution: Number(event.target.value) })}
+            >
+              <option value={2}>8分</option>
+              <option value={4}>16分</option>
+              <option value={6}>24分</option>
+              <option value={8}>32分</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase text-slate-300">シード</span>
+            <input
+              type="number"
+              className="rounded border border-slate-600 bg-slate-900 p-2"
+              value={chartConfig.seed}
+              onChange={(event) => onConfigChange({ seed: Number(event.target.value) })}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase text-slate-300">オフセット (ms)</span>
+            <input
+              type="range"
+              min={-120}
+              max={120}
+              value={offset}
+              onChange={(event) => setOffset(Number(event.target.value))}
+            />
+            <span className="text-xs text-slate-400">{offset}ms</span>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase text-slate-300">スクロール速度</span>
+            <input
+              type="range"
+              min={0.6}
+              max={2}
+              step={0.1}
+              value={scrollSpeed}
+              onChange={(event) => setScrollSpeed(Number(event.target.value))}
+            />
+            <span className="text-xs text-slate-400">x{scrollSpeed.toFixed(1)}</span>
+          </label>
+          <div className="flex items-end justify-between gap-2">
+            <button
+              type="button"
+              onClick={startGame}
+              className="flex-1 rounded bg-sky-500 px-3 py-2 font-semibold text-slate-900 transition hover:bg-sky-400"
+            >
+              スタート
+            </button>
+            <button
+              type="button"
+              onClick={stopGame}
+              className="rounded border border-slate-600 px-3 py-2 text-slate-200 transition hover:bg-slate-700"
+            >
+              ストップ
+            </button>
+          </div>
+        </section>
+      </header>
+
+      <main className="flex w-full max-w-5xl flex-col items-center gap-4">
+        <GameBoard
+          notes={noteStates}
+          currentTime={currentTime}
+          offsetSeconds={offsetSeconds}
+          scrollSpeed={scrollSpeed}
+          pressedLanes={pressed}
+        />
+        <section className="grid w-full max-w-3xl grid-cols-2 gap-4 rounded-xl bg-slate-800/40 p-4 text-sm sm:grid-cols-4">
+          <div>
+            <p className="text-xs uppercase text-slate-400">コンボ</p>
+            <p className="text-2xl font-semibold text-white">{stats.combo}</p>
+            <p className="text-xs text-slate-400">MAX {stats.maxCombo}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-slate-400">判定</p>
+            <ul className="space-y-1 text-xs text-slate-300">
+              <li>PERFECT: {stats.counts.PERFECT}</li>
+              <li>GREAT: {stats.counts.GREAT}</li>
+              <li>GOOD: {stats.counts.GOOD}</li>
+              <li>MISS: {stats.counts.MISS}</li>
+            </ul>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-slate-400">精度</p>
+            <p className="text-2xl font-semibold text-white">{formatAccuracy(stats.accuracy)}</p>
+            <p className="text-xs text-slate-400">{stats.totalJudged} / {totalNotes} notes</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-slate-400">ラスト判定</p>
+            <p className="text-2xl font-semibold text-sky-300">{stats.lastJudgement ?? '-'}</p>
+            <p className="text-xs text-slate-400">オフセット {offset}ms</p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,0 +1,73 @@
+import type { NoteState } from '../types';
+
+const laneColors = ['#60a5fa', '#34d399', '#fbbf24', '#f87171'];
+const keyLabels = ['D', 'F', 'J', 'K'];
+const boardHeight = 520;
+const judgementLine = boardHeight - 80;
+
+interface GameBoardProps {
+  notes: NoteState[];
+  currentTime: number;
+  offsetSeconds: number;
+  scrollSpeed: number;
+  pressedLanes: Record<number, boolean>;
+}
+
+const GameBoard = ({ notes, currentTime, offsetSeconds, scrollSpeed, pressedLanes }: GameBoardProps) => {
+  const pixelsPerSecond = 260 * scrollSpeed;
+
+  return (
+    <div className="relative flex w-full max-w-3xl gap-2 rounded-2xl border border-slate-700 bg-slate-900/80 p-3 shadow-lg">
+      {Array.from({ length: 4 }).map((_, lane) => (
+        <div
+          key={lane}
+          className="relative flex-1 overflow-hidden rounded-xl border bg-slate-950/60"
+          style={{ height: boardHeight, borderColor: `${laneColors[lane]}33` }}
+        >
+          <div className="absolute inset-0">
+            {notes
+              .filter((note) => note.lane === lane && note.status === 'pending')
+              .map((note) => {
+                const timeToHit = note.time - (currentTime + offsetSeconds);
+                if (timeToHit < -0.4) {
+                  return null;
+                }
+                const top = Math.min(
+                  boardHeight,
+                  Math.max(0, judgementLine - timeToHit * pixelsPerSecond)
+                );
+                return (
+                  <div
+                    key={note.id}
+                    className="absolute left-1/2 h-4 w-14 -translate-x-1/2 rounded-full shadow shadow-slate-900"
+                    style={{
+                      top,
+                      backgroundColor: laneColors[lane],
+                      boxShadow: `0 0 12px ${laneColors[lane]}55`
+                    }}
+                  />
+                );
+              })}
+          </div>
+          <div
+            className={`absolute bottom-16 left-1/2 h-1 w-20 -translate-x-1/2 rounded-full bg-white/80 shadow shadow-slate-900 transition ${
+              pressedLanes[lane] ? 'scale-105 bg-white' : ''
+            }`}
+          />
+          <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 flex-col items-center text-xs text-slate-200">
+            <span className="text-lg font-semibold">{keyLabels[lane]}</span>
+            <span className="text-[10px] uppercase tracking-[0.2em] text-slate-400">Lane {lane + 1}</span>
+          </div>
+        </div>
+      ))}
+      <div
+        className="pointer-events-none absolute left-0 right-0"
+        style={{ top: judgementLine }}
+      >
+        <div className="mx-3 h-0.5 bg-white/30" />
+      </div>
+    </div>
+  );
+};
+
+export default GameBoard;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -1,0 +1,105 @@
+import type { ChartData } from '../types';
+
+const PULSE_LENGTH = 0.12;
+const PULSE_FREQUENCY = 880;
+
+const isAudioSupported = () =>
+  typeof window !== 'undefined' &&
+  (window.AudioContext || (window as unknown as { webkitAudioContext?: AudioContext }).webkitAudioContext);
+
+const buildMetronomeBuffer = (context: AudioContext, chart: ChartData): AudioBuffer => {
+  const lastNoteTime = chart.notes.length > 0 ? chart.notes[chart.notes.length - 1].time : 0;
+  const duration = Math.max(chart.duration + 1, lastNoteTime + 1, 3);
+  const totalSamples = Math.ceil(duration * context.sampleRate);
+  const buffer = context.createBuffer(1, totalSamples, context.sampleRate);
+  const data = buffer.getChannelData(0);
+
+  chart.notes.forEach((note, index) => {
+    const startSample = Math.floor(note.time * context.sampleRate);
+    const length = Math.floor(PULSE_LENGTH * context.sampleRate);
+    for (let i = 0; i < length && startSample + i < data.length; i += 1) {
+      const t = i / context.sampleRate;
+      const envelope = Math.exp(-8 * t);
+      const accentBoost = index % (chart.config.beatsPerMeasure * chart.config.resolution) === 0 ? 1.2 : 1;
+      data[startSample + i] += Math.sin(2 * Math.PI * PULSE_FREQUENCY * t) * envelope * 0.4 * accentBoost;
+    }
+  });
+
+  return buffer;
+};
+
+export class AudioEngine {
+  private context: AudioContext | null = null;
+
+  private buffer: AudioBuffer | null = null;
+
+  private source: AudioBufferSourceNode | null = null;
+
+  private scheduledStart = 0;
+
+  private async ensureContext(): Promise<AudioContext | null> {
+    if (!isAudioSupported()) {
+      return null;
+    }
+
+    if (!this.context) {
+      const Constructor = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      this.context = new Constructor();
+    }
+
+    await this.context.resume();
+    return this.context;
+  }
+
+  async prepare(chart: ChartData): Promise<void> {
+    const context = await this.ensureContext();
+    if (!context) {
+      return;
+    }
+    this.stop();
+    this.buffer = buildMetronomeBuffer(context, chart);
+  }
+
+  async play(): Promise<void> {
+    const context = await this.ensureContext();
+    if (!context || !this.buffer) {
+      return;
+    }
+
+    this.stop();
+
+    const source = context.createBufferSource();
+    source.buffer = this.buffer;
+    source.connect(context.destination);
+    source.onended = () => {
+      if (this.source === source) {
+        this.source = null;
+      }
+    };
+
+    const startAt = context.currentTime + 0.1;
+    source.start(startAt);
+    this.source = source;
+    this.scheduledStart = startAt;
+  }
+
+  stop(): void {
+    if (this.source) {
+      try {
+        this.source.stop();
+      } catch (error) {
+        // ignore stop errors
+      }
+      this.source.disconnect();
+      this.source = null;
+    }
+    this.scheduledStart = 0;
+  }
+
+  getCurrentTime(): number {
+    if (!this.context || !this.source) {
+      return 0;
+    }
+    return Math.max(0, this.context.currentTime - this.scheduledStart);
+  }
+}

--- a/src/lib/chart.test.ts
+++ b/src/lib/chart.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { generateChart } from './chart';
+
+describe('generateChart', () => {
+  it('creates deterministic charts for identical config', () => {
+    const config = { bpm: 120, measures: 4, beatsPerMeasure: 4, resolution: 4, seed: 42 };
+    const chartA = generateChart(config);
+    const chartB = generateChart(config);
+
+    expect(chartA.notes).toHaveLength(chartB.notes.length);
+    chartA.notes.forEach((note, index) => {
+      expect(note.lane).toBe(chartB.notes[index]?.lane);
+      expect(note.time).toBeCloseTo(chartB.notes[index]?.time ?? 0, 10);
+    });
+  });
+
+  it('increases note density with higher resolution', () => {
+    const low = generateChart({ bpm: 120, measures: 2, beatsPerMeasure: 4, resolution: 2, seed: 1 });
+    const high = generateChart({ bpm: 120, measures: 2, beatsPerMeasure: 4, resolution: 8, seed: 1 });
+
+    expect(high.notes.length).toBeGreaterThan(low.notes.length);
+  });
+});

--- a/src/lib/chart.ts
+++ b/src/lib/chart.ts
@@ -1,0 +1,66 @@
+import type { ChartConfig, ChartData, Note } from '../types';
+
+const lanePattern = [0, 1, 2, 3, 2, 1];
+
+const createRng = (seed: number) => {
+  let value = seed % 2147483647;
+  if (value <= 0) {
+    value += 2147483646;
+  }
+  return () => {
+    value = (value * 16807) % 2147483647;
+    return (value - 1) / 2147483646;
+  };
+};
+
+export const generateChart = (config: ChartConfig): ChartData => {
+  const beatsPerMeasure = Math.max(1, Math.floor(config.beatsPerMeasure));
+  const resolution = Math.max(1, Math.floor(config.resolution));
+  const totalSteps = config.measures * beatsPerMeasure * resolution;
+  const secondsPerBeat = 60 / config.bpm;
+  const secondsPerStep = secondsPerBeat / resolution;
+  const rng = createRng(config.seed);
+
+  const notes: Note[] = [];
+
+  for (let step = 0; step < totalSteps; step += 1) {
+    const time = step * secondsPerStep;
+    const isDownbeat = step % resolution === 0;
+    const lane = lanePattern[step % lanePattern.length];
+
+    // Always place a note on strong beats to keep the rhythm predictable.
+    if (isDownbeat) {
+      notes.push({ id: `n-${step}-${lane}`, lane, time });
+      // Add a supporting chord on alternating measures.
+      if ((Math.floor(step / (beatsPerMeasure * resolution)) + lane) % 2 === 0) {
+        const pairedLane = (lane + 2) % 4;
+        notes.push({ id: `n-${step}-${pairedLane}`, lane: pairedLane, time });
+      }
+      continue;
+    }
+
+    // For offbeats use deterministic pseudo randomness to add syncopation.
+    const probability = 0.35 + (lane / 10);
+    if (rng() < probability) {
+      const offsetLane = (lane + (rng() > 0.5 ? 1 : 3)) % 4;
+      notes.push({ id: `n-${step}-${offsetLane}`, lane: offsetLane, time });
+    }
+  }
+
+  notes.sort((a, b) => a.time - b.time || a.lane - b.lane);
+
+  const lastTime = notes.length > 0 ? notes[notes.length - 1].time : totalSteps * secondsPerStep;
+
+  return {
+    notes,
+    duration: lastTime + 2,
+    secondsPerBeat,
+    config: {
+      bpm: config.bpm,
+      measures: config.measures,
+      beatsPerMeasure,
+      resolution,
+      seed: config.seed
+    }
+  };
+};

--- a/src/lib/judgement.test.ts
+++ b/src/lib/judgement.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { determineJudgement, judgementWindows } from './judgement';
+
+describe('determineJudgement', () => {
+  it('returns PERFECT for deltas within perfect window', () => {
+    expect(determineJudgement(judgementWindows.PERFECT - 0.001)).toBe('PERFECT');
+    expect(determineJudgement(-(judgementWindows.PERFECT - 0.001))).toBe('PERFECT');
+  });
+
+  it('falls back to GOOD for larger deltas', () => {
+    expect(determineJudgement(judgementWindows.GOOD - 0.001)).toBe('GOOD');
+  });
+
+  it('returns null outside windows', () => {
+    expect(determineJudgement(judgementWindows.GOOD + 0.05)).toBeNull();
+  });
+});

--- a/src/lib/judgement.ts
+++ b/src/lib/judgement.ts
@@ -1,0 +1,28 @@
+export type Judgement = 'PERFECT' | 'GREAT' | 'GOOD' | 'MISS';
+
+export const judgementWindows = {
+  PERFECT: 0.05,
+  GREAT: 0.1,
+  GOOD: 0.16
+} as const;
+
+export const judgementWeights: Record<Judgement, number> = {
+  PERFECT: 1,
+  GREAT: 0.75,
+  GOOD: 0.5,
+  MISS: 0
+};
+
+export const determineJudgement = (deltaSeconds: number): Judgement | null => {
+  const distance = Math.abs(deltaSeconds);
+  if (distance <= judgementWindows.PERFECT) {
+    return 'PERFECT';
+  }
+  if (distance <= judgementWindows.GREAT) {
+    return 'GREAT';
+  }
+  if (distance <= judgementWindows.GOOD) {
+    return 'GOOD';
+  }
+  return null;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,29 @@
+import type { Judgement } from './lib/judgement';
+
+export interface ChartConfig {
+  bpm: number;
+  measures: number;
+  beatsPerMeasure: number;
+  resolution: number;
+  seed: number;
+}
+
+export interface Note {
+  id: string;
+  lane: number;
+  time: number;
+}
+
+export type NoteStatus = Judgement | 'pending';
+
+export interface NoteState extends Note {
+  status: NoteStatus;
+  hitOffset?: number;
+}
+
+export interface ChartData {
+  notes: Note[];
+  duration: number;
+  secondsPerBeat: number;
+  config: ChartConfig;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        lane1: '#60a5fa',
+        lane2: '#34d399',
+        lane3: '#fbbf24',
+        lane4: '#f87171'
+      }
+    }
+  },
+  plugins: []
+} satisfies Config;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.*", "src/**/*.spec.*"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts", "tailwind.config.ts", "postcss.config.cjs"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts'
+  }
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript project with Tailwind, ESLint, Prettier, and Vitest configuration
- implement a four-lane rhythm game with auto-generated charts, Web Audio playback, scoring, and adjustable offset/scroll speed controls
- add unit tests covering chart generation and judgement windows plus a smoke test for the app shell

## Testing
- `npm install` *(fails: registry responds 403 Forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d151411360832d96c87c892784463f